### PR TITLE
Fix: Profile Layout Alignment

### DIFF
--- a/src/components/dashboard/profile/SettingsProfile.tsx
+++ b/src/components/dashboard/profile/SettingsProfile.tsx
@@ -164,8 +164,8 @@ export default function UserProfilePage() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div className="lg:col-span-1 space-y-6">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 pb-6 h-full">
+            <div className="lg:col-span-1 space-y-6 pb-5">
               <Card className="bg-black/40 backdrop-blur-md border-white/10 text-white overflow-hidden">
                 <CardHeader className="pb-2">
                   <CardTitle>Profile</CardTitle>
@@ -435,7 +435,7 @@ export default function UserProfilePage() {
                   </Card>
                 </TabsContent>
 
-                <TabsContent value="transactions" className="space-y-6">
+                <TabsContent value="transactions" className="space-y-6 pb-5">
                   <Card className="bg-black/40 backdrop-blur-md border-white/10 text-white">
                     <CardHeader>
                       <div className="flex flex-col md:flex-row justify-between md:items-center gap-4">
@@ -666,7 +666,7 @@ export default function UserProfilePage() {
 
                 <TabsContent
                   value="settings"
-                  className="space-y-6 overflow-auto"
+                  className="space-y-6 pb-5 overflow-auto"
                 >
                   <Card className="bg-black/40 backdrop-blur-md border-white/10 text-white">
                     <CardHeader>
@@ -675,7 +675,7 @@ export default function UserProfilePage() {
                         Manage your profile information and preferences
                       </CardDescription>
                     </CardHeader>
-                    <CardContent className="overflow-visible pb-8">
+                    <CardContent className="overflow-visible ">
                       <div className="space-y-6">
                         <div className="space-y-2">
                           <h3 className="text-sm font-medium">


### PR DESCRIPTION
# Pull Request for PolarisTrade - Close Issue #13

❗ **Pull Request Information**

This PR addresses layout overflow issues in the User Profile page, specifically in the Settings tab and Edit Profile functionality. The changes ensure that content no longer sticks to the bottom of the page, improving the overall user experience.


## 🌀 Summary of Changes
- [x] Fixed layout overflow issues in the "Settings" tab and "Edit Profile" form.
- [x] Added `overflow-auto` and `pb-5` to ensure proper scrolling and spacing.
- [x] Adjusted height and overflow behavior to prevent content from sticking to the bottom.

## 🛠 Testing
- Verified that the "Settings" tab and "Edit Profile" form no longer stick to the bottom.
- Confirmed that all tabs and forms are fully functional and visually consistent.

### Evidence Before Solution

<!-- Describe the behavior or issue before applying the solution. Use Loom to record a video showing the problem. Provide a link to the video. -->
![image](https://github.com/user-attachments/assets/c71b74cd-4de3-4dbd-b5f4-bebd24ecb54d)


### Evidence After Solution

<!-- Explain how the issue was fixed and demonstrate the corrected functionality. Use Loom to record another video showing the solution. Provide a link to the video. -->

- **Video**: [Link to Loom video](https://www.loom.com/share/66d53e7a72c94da6bc594440e4174fa5)


## 📂 Related Issue

<!-- Link the related issue so it automatically closes when this pull request is merged. -->

This pull request will **close #13** upon merging.

---

🎉 Thank you for reviewing this PR! 🎉
